### PR TITLE
[WIP] StyleRoot/StyleKeeper subclasses, resolveSortedMediaQueries plugin

### DIFF
--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -2,8 +2,8 @@
 /* eslint-disable new-cap */
 import React from "react";
 import ReactDOM from "react-dom";
-import Radium, { Style, StyleRoot } from "radium";
-import { Grid, Cell } from "../src/index";
+import { Style } from "radium";
+import { StyleRoot, Grid, Cell } from "../src/index";
 
 const colors = {
   formidared: "#FF4136",
@@ -224,6 +224,4 @@ App.styles = {
   }
 };
 
-const Wrapper = Radium(App);
-
-ReactDOM.render(<Wrapper/>, document.getElementById("content"));
+ReactDOM.render(<App />, document.getElementById("content"));

--- a/package.json
+++ b/package.json
@@ -22,12 +22,14 @@
     "builder": "^2.6.0",
     "builder-radium-component": "^0.2.7",
     "coveralls": "^2.11.6",
+    "lodash.contains": "^2.4.3",
     "lodash.initial": "^4.0.1",
     "lodash.last": "^3.0.0",
     "lodash.merge": "^4.1.0",
-    "radium": "^0.16",
+    "radium": "^0.16.6",
     "react": "^0.14.6",
-    "react-dom": "^0.14.6"
+    "react-dom": "^0.14.6",
+    "sort-media-queries": "^0.2.2"
   },
   "devDependencies": {
     "babel-polyfill": "^6.5.0",

--- a/src/components/cell.js
+++ b/src/components/cell.js
@@ -1,6 +1,7 @@
 /* eslint-disable new-cap */
 import React, { PropTypes } from "react";
 import Radium from "radium";
+import resolveSortedMediaQueries from "./plugins/resolve-sorted-media-queries";
 
 const Cell = (props) => {
   return (
@@ -39,4 +40,15 @@ Cell.propTypes = {
   style: PropTypes.object
 };
 
-export default Radium(Cell);
+export default Radium({
+  plugins: [
+    Radium.Plugins.mergeStyleArray,
+    Radium.Plugins.checkProps,
+    resolveSortedMediaQueries,
+    Radium.Plugins.resolveInteractionStyles,
+    Radium.Plugins.keyframes,
+    Radium.Plugins.visited,
+    Radium.Plugins.prefix,
+    Radium.Plugins.checkProps
+  ]
+})(Cell);

--- a/src/components/grid.js
+++ b/src/components/grid.js
@@ -2,6 +2,7 @@
 import React, { PropTypes } from "react";
 import Radium from "radium";
 import resolveCells from "./util/resolve-cells";
+import resolveSortedMediaQueries from "./plugins/resolve-sorted-media-queries";
 
 const Grid = (props) => {
   const styles = {
@@ -61,12 +62,23 @@ Grid.defaultProps = {
 
   breakpoints: {
     small: "@media only screen and (max-width: 640px)",
-    medium: "@media only screen and (min-width: 641px) and (max-width: 1024px)",
-    large: "@media only screen and (min-width: 1025px) and (max-width: 1440px)",
+    medium: "@media only screen and (min-width: 641px)",
+    large: "@media only screen and (min-width: 1025px)",
     xlarge: "@media only screen and (min-width: 1441px)"
   },
 
   gutter: "16px"
 };
 
-export default Radium(Grid);
+export default Radium({
+  plugins: [
+    Radium.Plugins.mergeStyleArray,
+    Radium.Plugins.checkProps,
+    resolveSortedMediaQueries,
+    Radium.Plugins.resolveInteractionStyles,
+    Radium.Plugins.keyframes,
+    Radium.Plugins.visited,
+    Radium.Plugins.prefix,
+    Radium.Plugins.checkProps
+  ]
+})(Grid);

--- a/src/components/plugins/resolve-sorted-media-queries.js
+++ b/src/components/plugins/resolve-sorted-media-queries.js
@@ -1,0 +1,193 @@
+/* eslint-env browser */
+
+let _windowMatchMedia;
+const _getWindowMatchMedia = (ExecutionEnvironment) => {
+  if (_windowMatchMedia === undefined) {
+    _windowMatchMedia = !!ExecutionEnvironment.canUseDOM &&
+      !!window &&
+      !!window.matchMedia &&
+      ((mediaQueryString) => window.matchMedia(mediaQueryString)) ||
+      null;
+  }
+  return _windowMatchMedia;
+};
+
+const _filterObject = (
+  obj: Object,
+  predicate: (value: any, key: string) => bool
+): Object => {
+  return Object.keys(obj)
+    .filter((key) => predicate(obj[key], key))
+    .reduce(
+      (result, key) => {
+        result[key] = obj[key];
+        return result;
+      },
+      {}
+    );
+};
+
+const _removeMediaQueries = (style) => {
+  return Object.keys(style).reduce(
+    (styleWithoutMedia, key) => {
+      if (key.indexOf("@media") !== 0) {
+        styleWithoutMedia[key] = style[key];
+      }
+      return styleWithoutMedia;
+    },
+    {}
+  );
+};
+
+const _topLevelRulesToCSS = ({
+  addCSS,
+  appendImportantToEachValue,
+  cssRuleSetToString,
+  hash,
+  isNestedStyle,
+  style,
+  userAgent
+}) => {
+  let className = "";
+  Object.keys(style)
+  .filter((name) => name.indexOf("@media") === 0)
+  .map((query) => {
+    const topLevelRules = appendImportantToEachValue(
+      _filterObject(
+        style[query],
+        (value) => !isNestedStyle(value),
+      )
+    );
+
+    if (!Object.keys(topLevelRules).length) {
+      return;
+    }
+
+    const ruleCSS = cssRuleSetToString(
+      "",
+      topLevelRules,
+      userAgent
+    );
+
+    const mediaQueryClassName = `rmq-${hash(query + ruleCSS)}`;
+
+    // The horrible hack. Add "[CASCADE]" to the end of the rule
+    // so that the GridStyleKeeper can detect that this is a
+    // sorted media query.
+
+    // Gross.
+    const css = `${query}{ .${mediaQueryClassName}${ruleCSS}}[CASCADE]`;
+    addCSS(css);
+
+    className += (className ? " " : "") + mediaQueryClassName;
+  });
+  return className;
+};
+
+const _subscribeToMediaQuery = ({
+  listener,
+  listenersByQuery,
+  matchMedia,
+  mediaQueryListsByQuery,
+  query
+}) => {
+  query = query.replace("@media ", "");
+
+  let mql = mediaQueryListsByQuery[query];
+  if (!mql && matchMedia) {
+    mediaQueryListsByQuery[query] = mql = matchMedia(query);
+  }
+
+  if (!listenersByQuery || !listenersByQuery[query]) {
+    mql.addListener(listener);
+
+    listenersByQuery[query] = {
+      remove() {
+        mql.removeListener(listener);
+      }
+    };
+  }
+  return mql;
+};
+
+const resolveMediaQueries = ({
+  ExecutionEnvironment,
+  addCSS,
+  appendImportantToEachValue,
+  config,
+  cssRuleSetToString,
+  getComponentField,
+  getGlobalState,
+  hash,
+  isNestedStyle,
+  mergeStyles,
+  props,
+  setState,
+  style
+}) => { // eslint-disable-line no-shadow
+  let newStyle = _removeMediaQueries(style);
+  const mediaQueryClassNames = _topLevelRulesToCSS({
+    addCSS,
+    appendImportantToEachValue,
+    cssRuleSetToString,
+    hash,
+    isNestedStyle,
+    style,
+    userAgent: config.userAgent
+  });
+
+  const newProps = mediaQueryClassNames ? {
+    className: mediaQueryClassNames +
+      (props.className ? ` ${props.className}` : "")
+  } : null;
+
+  const matchMedia = config.matchMedia ||
+    _getWindowMatchMedia(ExecutionEnvironment);
+
+  if (!matchMedia) {
+    return {
+      props: newProps,
+      style: newStyle
+    };
+  }
+
+  const listenersByQuery = {
+    ...getComponentField("_radiumMediaQueryListenersByQuery")
+  };
+  const mediaQueryListsByQuery =
+    getGlobalState("mediaQueryListsByQuery") || {};
+
+  Object.keys(style)
+  .filter((name) => name.indexOf("@media") === 0)
+  .map((query) => {
+    const nestedRules = _filterObject(style[query], isNestedStyle);
+
+    if (!Object.keys(nestedRules).length) {
+      return;
+    }
+
+    const mql = _subscribeToMediaQuery({
+      listener: () => setState(query, mql.matches, "_all"),
+      listenersByQuery,
+      matchMedia,
+      mediaQueryListsByQuery,
+      query
+    });
+
+    // Apply media query states
+    if (mql.matches) {
+      newStyle = mergeStyles([newStyle, nestedRules]);
+    }
+  });
+
+  return {
+    componentFields: {
+      _radiumMediaQueryListenersByQuery: listenersByQuery
+    },
+    globalState: {mediaQueryListsByQuery},
+    props: newProps,
+    style: newStyle
+  };
+};
+
+export default resolveMediaQueries;

--- a/src/components/style-root.js
+++ b/src/components/style-root.js
@@ -1,7 +1,6 @@
 /* eslint-disable new-cap */
 import Enhancer from "radium/lib/enhancer";
 import StyleRoot from "radium/lib/components/style-root";
-// import StyleSheet from "radium/lib/style-sheet";
 
 import StyleKeeper from "./util/style-keeper";
 

--- a/src/components/style-root.js
+++ b/src/components/style-root.js
@@ -1,0 +1,30 @@
+/* eslint-disable new-cap */
+import Enhancer from "radium/lib/enhancer";
+import StyleRoot from "radium/lib/components/style-root";
+// import StyleSheet from "radium/lib/style-sheet";
+
+import StyleKeeper from "./util/style-keeper";
+
+const _getStyleKeeper = (instance) => {
+  if (!instance._radiumStyleKeeper) {
+    const userAgent = (
+      instance.props.radiumConfig && instance.props.radiumConfig.userAgent
+    ) || (
+      instance.context._radiumConfig && instance.context._radiumConfig.userAgent
+    );
+    instance._radiumStyleKeeper = new StyleKeeper(userAgent);
+  }
+
+  return instance._radiumStyleKeeper;
+};
+
+class GridStyleRoot extends StyleRoot {
+  constructor() {
+    super(...arguments);
+
+    this._radiumStyleKeeper = null;
+    _getStyleKeeper(this);
+  }
+}
+
+export default Enhancer(GridStyleRoot);

--- a/src/components/util/style-keeper.js
+++ b/src/components/util/style-keeper.js
@@ -1,0 +1,43 @@
+import StyleKeeper from "radium/lib/style-keeper";
+import contains from "lodash.contains";
+import sortMediaQueries from "sort-media-queries";
+
+export default class GridStyleKeeper extends StyleKeeper {
+  constructor(userAgent: string) {
+    super(userAgent);
+    this._cascadingCSS = [];
+  }
+
+  addCSS(css: string): {remove: () => void} {
+    const cascade = css.indexOf("[CASCADE]") !== -1;
+    if (cascade) {
+      const cleanRule = css.replace(/\[CASCADE\]/g, "");
+      if (!contains(this._cascadingCSS, cleanRule)) {
+        this._cascadingCSS.push(cleanRule);
+        this._emitChange();
+      }
+    } else if (!this._cssSet[css]) {
+      this._cssSet[css] = true;
+      this._emitChange();
+    }
+
+    return {
+      // Must be fat arrow to capture `this`
+      remove: () => {
+        if (cascade) {
+          const index = this._cascadingCSS.indexOf(css);
+          this._cascadingCSS.splice(index, 1);
+        } else {
+          delete this._cssSet[css];
+        }
+        this._emitChange();
+      }
+    };
+  }
+
+  getCSS(): string {
+    return Object.keys(this._cssSet)
+      .concat(sortMediaQueries(this._cascadingCSS))
+      .join("\n");
+  }
+}

--- a/src/components/util/style-keeper.js
+++ b/src/components/util/style-keeper.js
@@ -9,7 +9,7 @@ export default class GridStyleKeeper extends StyleKeeper {
   }
 
   addCSS(css: string): {remove: () => void} {
-    const cascade = css.indexOf("[CASCADE]") !== -1;
+    const cascade = css.indexOf("[CASCADE]") !== -1; // eslint-disable-line no-magic-numbers
     if (cascade) {
       const cleanRule = css.replace(/\[CASCADE\]/g, "");
       if (!contains(this._cascadingCSS, cleanRule)) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 import GridImport from "./components/grid";
 import CellImport from "./components/cell";
+import GridStyleRoot from "./components/style-root";
 
 export const Grid = GridImport;
 export const Cell = CellImport;
+export const StyleRoot = GridStyleRoot;


### PR DESCRIPTION
This PR allow us to sort media queries by size instead of by definition time (the Radium default). 
The StyleRoot is backwards compatible: it doesn't affect vanilla Radium components or their precedence rules with media queries.

These changes will allow for a wider range of custom media queries, and, furthermore, will allow us to change our default media queries to ones defined by `min-width`. The new default will make custom styles on Cells much more intuitive for mobile-first design.

Unfortunately, this is a breaking change, but we planned on changing the default breakpoints anyway, which is already a breaking change. In addition, the upgrade path is simple.

Old:
```es6
import Radium, { Style, StyleRoot } from "radium";
import { Grid, Cell } from "../src/index";
```

New:
```es6
+import { Style } from "radium";
+import { StyleRoot, Grid, Cell } from "../src/index";
```

This is, without question, a horrible hack. If anyone can find a better way to make this happen, I'd love to implement it.