### PR TITLE
Add order breakpoints

### DIFF
--- a/src/components/cell.js
+++ b/src/components/cell.js
@@ -16,24 +16,27 @@ Cell.propTypes = {
   width: PropTypes.string,
   horizontalAlign: horizontalPropType,
   verticalAlign: verticalPropType,
+  order: PropTypes.number,
 
   smallWidth: PropTypes.string,
   smallHorizontalAlign: horizontalPropType,
   smallVerticalAlign: verticalPropType,
+  smallOrder: PropTypes.number,
 
   mediumWidth: PropTypes.string,
   mediumHorizontalAlign: horizontalPropType,
   mediumVerticalAlign: verticalPropType,
+  mediumOrder: PropTypes.number,
 
   largeWidth: PropTypes.string,
   largeHorizontalAlign: horizontalPropType,
   largeVerticalAlign: verticalPropType,
+  largeOrder: PropTypes.number,
 
   xlargeWidth: PropTypes.string,
   xlargeHorizontalAlign: horizontalPropType,
   xlargeVerticalAlign: verticalPropType,
-
-  order: PropTypes.number,
+  xlargeOrder: PropTypes.number,
 
   children: PropTypes.node,
   style: PropTypes.object

--- a/src/components/util/resolve-cell-defaults.js
+++ b/src/components/util/resolve-cell-defaults.js
@@ -30,7 +30,8 @@ const resolveCellDefaults = (props) => {
       cellBreakpointDefault: {
         width: props[`${size}Width`],
         horizontalAlign: props[`${size}Align`],
-        verticalAlign: props[`${size}VerticalAlign`]
+        verticalAlign: props[`${size}VerticalAlign`],
+        order: props[`${size}Order`]
       }
     };
   });

--- a/test/client/spec/components/grid.spec.jsx
+++ b/test/client/spec/components/grid.spec.jsx
@@ -553,6 +553,44 @@ describe("Grid", () => {
     });
   });
 
+  it("should allow overridable individual cell breakpoint order", () => {
+    const grid = (
+      <Grid>
+        <Cell>
+          <p>testing</p>
+        </Cell>
+        <Cell
+          smallOrder={1}
+          mediumOrder={2}
+          largeOrder={3}
+          xlargeOrder={4}
+        >
+          <p>testing!</p>
+        </Cell>
+        <Cell>
+          <p>testing?</p>
+        </Cell>
+      </Grid>
+    );
+    const cells = resolveCells(grid.props);
+
+    testCellsOneBreakpoint([cells[1]], "small", (style) => {
+      expect(style.order).to.deep.equal(1);
+    });
+
+    testCellsOneBreakpoint([cells[1]], "medium", (style) => {
+      expect(style.order).to.deep.equal(2);
+    });
+
+    testCellsOneBreakpoint([cells[1]], "large", (style) => {
+      expect(style.order).to.deep.equal(3);
+    });
+
+    testCellsOneBreakpoint([cells[1]], "xlarge", (style) => {
+      expect(style.order).to.deep.equal(4);
+    });
+  });
+
 
   it("should allow customizable fixed gutters", () => {
     const grid = (


### PR DESCRIPTION
This adds breakpoint awareness for order prop so that we can change a `Cell` order depending on the breakpoint.

Fixes #22 