### PR TITLE
React.PropTypes deprecated, use prop-types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "builder-radium-component-dev": "^2.1.2",
     "chai": "^3.2.0",
     "mocha": "^3.1.2",
+    "prop-types": "^15.5.10",
     "radium": "^0.18.1",
     "react": "^15.3.2",
     "react-addons-test-utils": "^15.3.2",

--- a/src/components/cell.js
+++ b/src/components/cell.js
@@ -1,5 +1,6 @@
 /* eslint-disable new-cap */
-import React, { PropTypes } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 import Radium from "radium";
 
 const Cell = (props) => {

--- a/src/components/grid.js
+++ b/src/components/grid.js
@@ -1,5 +1,6 @@
 /* eslint-disable new-cap */
-import React, { PropTypes } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 import Radium from "radium";
 import resolveCells from "./util/resolve-cells";
 


### PR DESCRIPTION
https://facebook.github.io/react/warnings/dont-call-proptypes.html
React.PropTypes is deprecated, this PR switches to prop-types package