### PR TITLE
Changed to Proptypes Package to remove deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "coveralls": "^2.11.14",
     "lodash.initial": "^4.1.1",
     "lodash.last": "^3.0.0",
-    "lodash.merge": "^4.6.0"
+    "lodash.merge": "^4.6.0",
+    "prop-types": "^15.5.10"
   },
   "devDependencies": {
     "babel-polyfill": "^6.16.0",
@@ -42,7 +43,7 @@
     "webpack-dev-server": "^1.16.2"
   },
   "peerDependencies": {
-    "radium": "^0.18.1",
+    "radium": "^0.18.1 || ^0.19.0",
     "react": "^0.14.0 || ^15.0.0-0",
     "react-dom": "^0.14.0 || ^15.0.0-0"
   },

--- a/src/components/grid.js
+++ b/src/components/grid.js
@@ -1,5 +1,6 @@
 /* eslint-disable new-cap */
-import React, { PropTypes } from "react";
+import React from "react";
+import PropTypes from 'prop-types';
 import Radium from "radium";
 import resolveCells from "./util/resolve-cells";
 


### PR DESCRIPTION
As of React v15.5 using React.Proptypes is deprecated https://facebook.github.io/react/warnings/dont-call-proptypes.html

Change to utilize the supported proptypes package from npm. 

Removes warning.
`Accessing PropTypes via the main React package is deprecated`